### PR TITLE
fix: don't use '\' in imports on Windows

### DIFF
--- a/lib/src/step_file.dart
+++ b/lib/src/step_file.dart
@@ -4,7 +4,7 @@ import 'package:path/path.dart' as p;
 class StepFile {
   StepFile(String featureDir, this.package, this.line)
       : filename = p.join(featureDir, 'step', '${getStepFilename(line)}.dart'),
-        import = p.join('.', 'step', '${getStepFilename(line)}.dart');
+        import = p.join('.', 'step', '${getStepFilename(line)}.dart').replaceAll('\\', '/');
 
   final String filename;
   final String import;


### PR DESCRIPTION
Fixes #1