### PR TITLE
improvement: avoid avoid_types_on_closure_parameters by not specifying type in lambda

### DIFF
--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -67,8 +67,7 @@ void _parseFeature(
 }
 
 void _parseScenario(StringBuffer sb, List<BddLine> scenario) {
-  sb.writeln(
-      '    testWidgets(\'${scenario.first.value}\', (WidgetTester tester) async {');
+  sb.writeln('    testWidgets(\'${scenario.first.value}\', (tester) async {');
 
   for (final step in scenario.skip(1)) {
     sb.writeln('      await ${getStepMethodCall(step.value)};');


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1901832/94767355-78948b00-03ef-11eb-934b-3072603e6987.png)


Whilst I could also have added `avoid_types_on_closure_parameters` to the default ignore list, I figured it made more sense to just take the lint's advice.