### PR TITLE
improvement: generate features in a .g.dart file

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,6 +2,6 @@ builders:
   featureBuilder:
     import: "package:bdd_widget_test/bdd_widget_test.dart"
     builder_factories: ["featureBuilder"]
-    build_extensions: {".feature": [".dart"]}
+    build_extensions: {".feature": [".feature.g.dart"]}
     build_to: source
     auto_apply: root_package

--- a/lib/bdd_widget_test.dart
+++ b/lib/bdd_widget_test.dart
@@ -13,7 +13,7 @@ class FeatureBuilder implements Builder {
     final feature = FeatureFile(
         path: inputId.path, package: inputId.package, input: contents);
 
-    var featureDart = inputId.changeExtension('_test.dart');
+    var featureDart = inputId.changeExtension('.feature.g.dart');
     await buildStep.writeAsString(featureDart, feature.dartContent);
 
     for (final step in feature.getStepFiles()) {
@@ -31,6 +31,6 @@ class FeatureBuilder implements Builder {
 
   @override
   final buildExtensions = const {
-    '.feature': ['_test.dart']
+    '.feature': ['.feature.g.dart']
   };
 }

--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -67,8 +67,7 @@ void _parseFeature(
 }
 
 void _parseScenario(StringBuffer sb, List<BddLine> scenario) {
-  sb.writeln(
-      '    testWidgets(\'${scenario.first.value}\', (WidgetTester tester) async {');
+  sb.writeln('    testWidgets(\'${scenario.first.value}\', (tester) async {');
 
   for (final step in scenario.skip(1)) {
     sb.writeln('      await ${getStepMethodCall(step.value)};');


### PR DESCRIPTION
Lots of Flutter devs, myself included, do not like committing generated code. Such code is normally indicated with a `.g.dart` suffix to make it easy to ignore. This PR updates `bdd_widget_test` to generate feature code in a `$NAME.feature.g.dart` file alongside the `$NAME.feature` file.

This _is_ a breaking change, so I can appreciate why you might take this on hesitantly, or even reject it altogether. However, unless I'm missing something (entirely possible), I think this would be a warranted break (and is super easy to fix for consumers).