### PR TITLE
Feature: Add custom tester type, name and scenario parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.6.1] - Allow custom tester type, name and scenario parameters
+* Allow addition of custom tester type from other test packages using `@testerType:` tag the value can be like `PatrolIntegrationTester` instead of `WidgetTester`(default) 
+* Allow addition of custom tester name using `@testerName:` tag, the value can be like `$`, `integrationTest` instead of `tester` leaving `tester`(default)
+* Allow passing scenario parameters using `@scenarioParams:` tag, for example: `@scenarioParams: skip: false, timeout: Timeout(Duration(seconds: 1))` and many more. 
+* Though these additions do not affect predefined steps.
 ## [1.6.0] - Change step folder destination
 
 * **BREAKING CHANGE** - Introduce relative and absolute paths for step folder destination

--- a/example/test/sample_test.dart
+++ b/example/test/sample_test.dart
@@ -15,9 +15,11 @@ void main() {
     Future<void> bddSetUp(WidgetTester tester) async {
       await theAppIsRunning(tester);
     }
+
     Future<void> bddTearDown(WidgetTester tester) async {
       await iDoNotSeeText(tester, 'surprise');
     }
+
     testWidgets('''Initial counter value is 0''', (tester) async {
       try {
         await bddSetUp(tester);
@@ -35,7 +37,8 @@ void main() {
         await bddTearDown(tester);
       }
     });
-    testWidgets('''Outline: Plus button increases the counter (0, '0')''', (tester) async {
+    testWidgets('''Outline: Plus button increases the counter (0, '0')''',
+        (tester) async {
       try {
         await bddSetUp(tester);
         await theAppIsRunning(tester);
@@ -45,7 +48,8 @@ void main() {
         await bddTearDown(tester);
       }
     });
-    testWidgets('''Outline: Plus button increases the counter (1, '1')''', (tester) async {
+    testWidgets('''Outline: Plus button increases the counter (1, '1')''',
+        (tester) async {
       try {
         await bddSetUp(tester);
         await theAppIsRunning(tester);
@@ -55,7 +59,8 @@ void main() {
         await bddTearDown(tester);
       }
     });
-    testWidgets('''Outline: Plus button increases the counter (42, '42')''', (tester) async {
+    testWidgets('''Outline: Plus button increases the counter (42, '42')''',
+        (tester) async {
       try {
         await bddSetUp(tester);
         await theAppIsRunning(tester);

--- a/lib/src/feature_file.dart
+++ b/lib/src/feature_file.dart
@@ -2,6 +2,8 @@ import 'package:bdd_widget_test/src/bdd_line.dart';
 import 'package:bdd_widget_test/src/feature_generator.dart';
 import 'package:bdd_widget_test/src/generator_options.dart';
 import 'package:bdd_widget_test/src/step_file.dart';
+import 'package:bdd_widget_test/src/util/common.dart';
+import 'package:bdd_widget_test/src/util/constants.dart';
 
 class FeatureFile {
   FeatureFile({
@@ -14,6 +16,18 @@ class FeatureFile {
   }) : _lines = _prepareLines(
           input.split('\n').map((line) => line.trim()).map(BddLine.new),
         ) {
+    _testerType = parseCustomTagFromFeatureTagLine(
+      _lines,
+      generatorOptions.testerType,
+      testerTypeTag,
+    );
+
+    _testerName = parseCustomTagFromFeatureTagLine(
+      _lines,
+      generatorOptions.testerName,
+      testerNameTag,
+    );
+
     _stepFiles = _lines
         .where((line) => line.type == LineType.step)
         .map(
@@ -23,12 +37,16 @@ class FeatureFile {
             e.value,
             existingSteps,
             generatorOptions,
+            _testerType,
+            _testerName,
           ),
         )
         .toList();
   }
 
   late List<StepFile> _stepFiles;
+  late String _testerType;
+  late String _testerName;
 
   final String featureDir;
   final String package;
@@ -41,6 +59,8 @@ class FeatureFile {
         _lines,
         getStepFiles(),
         generatorOptions.testMethodName,
+        _testerType,
+        _testerName,
         isIntegrationTest,
       );
 

--- a/lib/src/generator_options.dart
+++ b/lib/src/generator_options.dart
@@ -2,7 +2,9 @@ import 'package:bdd_widget_test/src/util/fs.dart';
 import 'package:bdd_widget_test/src/util/isolate_helper.dart';
 import 'package:yaml/yaml.dart';
 
-const _defaultTestName = 'testWidgets';
+const _defaultTestMethodName = 'testWidgets';
+const _defaultTesterType = 'WidgetTester';
+const _defaultTesterName = 'tester';
 const _stepFolderName = './step';
 
 class GeneratorOptions {
@@ -10,14 +12,20 @@ class GeneratorOptions {
     String? testMethodName,
     List<String>? externalSteps,
     String? stepFolderName,
+    String? testerType,
+    String? testerName,
     this.include,
   })  : stepFolder = stepFolderName ?? _stepFolderName,
-        testMethodName = testMethodName ?? _defaultTestName,
+        testMethodName = testMethodName ?? _defaultTestMethodName,
+        testerType = testerType ?? _defaultTesterType,
+        testerName = testerName ?? _defaultTesterName,
         externalSteps = externalSteps ?? const [];
 
   factory GeneratorOptions.fromMap(Map<String, dynamic> json) =>
       GeneratorOptions(
         testMethodName: json['testMethodName'] as String?,
+        testerType: json['testerType'] as String?,
+        testerName: json['testerName'] as String?,
         externalSteps: (json['externalSteps'] as List?)?.cast<String>(),
         stepFolderName: json['stepFolderName'] as String?,
         include: json['include'] is String
@@ -27,6 +35,8 @@ class GeneratorOptions {
 
   final String stepFolder;
   final String testMethodName;
+  final String testerType;
+  final String testerName;
   final List<String>? include;
   final List<String> externalSteps;
 }
@@ -60,6 +70,8 @@ GeneratorOptions readFromUri(Uri uri) {
   final doc = loadYamlNode(rawYaml) as YamlMap;
   return GeneratorOptions(
     testMethodName: doc['testMethodName'] as String?,
+    testerType: doc['testerType'] as String?,
+    testerName: doc['testerName'] as String?,
     externalSteps: (doc['externalSteps'] as List?)?.cast<String>(),
     stepFolderName: doc['stepFolderName'] as String?,
     include: doc['include'] is String
@@ -70,9 +82,13 @@ GeneratorOptions readFromUri(Uri uri) {
 
 GeneratorOptions merge(GeneratorOptions a, GeneratorOptions b) =>
     GeneratorOptions(
-      testMethodName: a.testMethodName != _defaultTestName
+      testMethodName: a.testMethodName != _defaultTestMethodName
           ? a.testMethodName
           : b.testMethodName,
+      testerType:
+          a.testerType != _defaultTesterType ? a.testerType : b.testerType,
+      testerName:
+          a.testerName != _defaultTesterName ? a.testerName : b.testerName,
       stepFolderName:
           a.stepFolder != _stepFolderName ? a.stepFolder : b.stepFolder,
       externalSteps: [...a.externalSteps, ...b.externalSteps],

--- a/lib/src/scenario_generator.dart
+++ b/lib/src/scenario_generator.dart
@@ -9,31 +9,41 @@ void parseScenario(
   bool hasSetUp,
   bool hasTearDown,
   String testMethodName,
+  String testerName,
   List<String> tags,
+  String scenarioParams,
 ) {
   sb.writeln(
-    "    $testMethodName('''$scenarioTitle''', (tester) async {",
+    "    $testMethodName('''$scenarioTitle''', ($testerName) async {",
   );
   if (hasTearDown) {
     sb.writeln('      try {');
   }
   final spaces = hasTearDown ? '        ' : '      ';
   if (hasSetUp) {
-    sb.writeln('${spaces}await $setUpMethodName(tester);');
+    sb.writeln('${spaces}await $setUpMethodName($testerName);');
   }
 
   for (final step in scenario) {
-    sb.writeln('${spaces}await ${getStepMethodCall(step.value)};');
+    sb.writeln('${spaces}await ${getStepMethodCall(step.value, testerName)};');
   }
 
   if (hasTearDown) {
     sb.writeln('      } finally {');
-    sb.writeln('        await $tearDownMethodName(tester);');
+    sb.writeln('        await $tearDownMethodName($testerName);');
     sb.writeln('      }');
   }
   sb.writeln(
-    '    }${tags.isNotEmpty ? ", tags: ['${tags.join("', '")}']" : ''});',
+    '    }${tags.isNotEmpty ? ", tags: ['${tags.join("', '")}']" : ''}${scenarioParams.isNotEmpty ? ',' : ');'}',
   );
+  if (scenarioParams.isNotEmpty) {
+    for (final param in scenarioParams.split(', ')) {
+      sb.writeln('     $param,');
+    }
+    sb.writeln(
+      '     );',
+    );
+  }
 }
 
 List<List<BddLine>> generateScenariosFromScenaioOutline(

--- a/lib/src/step/generic_step.dart
+++ b/lib/src/step/generic_step.dart
@@ -3,36 +3,47 @@ import 'package:bdd_widget_test/src/step/bdd_step.dart';
 import 'package:bdd_widget_test/src/step_generator.dart';
 
 class GenericStep implements BddStep {
-  GenericStep(this.methodName, this.rawLine);
+  GenericStep(
+    this.methodName,
+    this.rawLine,
+    this.testerType,
+    this.customTesterName,
+  );
 
   final String rawLine;
   final String methodName;
+  final String testerType;
+  final String customTesterName;
 
   @override
   String get content => '''
 import 'package:flutter_test/flutter_test.dart';
 
-${getStepSignature(rawLine)} {
+${getStepSignature(rawLine, testerType, customTesterName)} {
   throw UnimplementedError();
 }
 ''';
 
-  String getStepSignature(String stepLine) {
+  String getStepSignature(
+    String stepLine,
+    String testerType,
+    String testerName,
+  ) {
     final params = parseRawStepLine(stepLine).skip(1);
     if (params.isEmpty) {
       final examples = examplesRegExp.allMatches(stepLine);
       if (examples.isEmpty) {
-        return 'Future<void> $methodName(WidgetTester tester) async';
+        return 'Future<void> $methodName($testerType $testerName) async';
       } else {
-        return _generateSignature(examples.length);
+        return _generateSignature(examples.length, testerName);
       }
     }
-    return _generateSignature(params.length);
+    return _generateSignature(params.length, testerName);
   }
 
-  String _generateSignature(int paramsCount) {
+  String _generateSignature(int paramsCount, String testerName) {
     final p = List.generate(paramsCount, (index) => index + 1);
     final methodParameters = p.map((p) => 'dynamic param$p').join(', ');
-    return 'Future<void> $methodName(WidgetTester tester, $methodParameters) async';
+    return 'Future<void> $methodName($testerType $testerName, $methodParameters) async';
   }
 }

--- a/lib/src/step_file.dart
+++ b/lib/src/step_file.dart
@@ -18,14 +18,6 @@ abstract class StepFile {
   ) {
     final file = '${getStepFilename(line)}.dart';
 
-    final testerType = testerTypeTagValue.isNotEmpty
-        ? testerTypeTagValue
-        : generatorOptions.testerType;
-
-    final testerName = testerNameTagValue.isNotEmpty
-        ? testerNameTagValue
-        : generatorOptions.testerName;
-
     if (existingSteps.containsKey(file)) {
       final import =
           p.join('.', existingSteps[file], file).replaceAll(r'\', '/');
@@ -48,8 +40,8 @@ abstract class StepFile {
         filename,
         package,
         line,
-        testerType,
-        testerName,
+        testerTypeTagValue,
+        testerNameTagValue,
       );
     }
 
@@ -63,8 +55,8 @@ abstract class StepFile {
       filename,
       package,
       line,
-      testerType,
-      testerName,
+      testerTypeTagValue,
+      testerNameTagValue,
     );
   }
 }

--- a/lib/src/step_file.dart
+++ b/lib/src/step_file.dart
@@ -13,8 +13,18 @@ abstract class StepFile {
     String line,
     Map<String, String> existingSteps,
     GeneratorOptions generatorOptions,
+    String testerTypeTagValue,
+    String testerNameTagValue,
   ) {
     final file = '${getStepFilename(line)}.dart';
+
+    final testerType = testerTypeTagValue.isNotEmpty
+        ? testerTypeTagValue
+        : generatorOptions.testerType;
+
+    final testerName = testerNameTagValue.isNotEmpty
+        ? testerNameTagValue
+        : generatorOptions.testerName;
 
     if (existingSteps.containsKey(file)) {
       final import =
@@ -33,7 +43,14 @@ abstract class StepFile {
       final import =
           p.join(generatorOptions.stepFolder, file).replaceAll(r'\', '/');
       final filename = p.join(featureDir, generatorOptions.stepFolder, file);
-      return NewStepFile._(import, filename, package, line);
+      return NewStepFile._(
+        import,
+        filename,
+        package,
+        line,
+        testerType,
+        testerName,
+      );
     }
 
     final pathToTestFolder = p.relative(testFolderName, from: featureDir);
@@ -41,19 +58,35 @@ abstract class StepFile {
         .join(pathToTestFolder, generatorOptions.stepFolder, file)
         .replaceAll(r'\', '/');
     final filename = p.join(testFolderName, generatorOptions.stepFolder, file);
-    return NewStepFile._(import, filename, package, line);
+    return NewStepFile._(
+      import,
+      filename,
+      package,
+      line,
+      testerType,
+      testerName,
+    );
   }
 }
 
 class NewStepFile extends StepFile {
-  const NewStepFile._(super.import, this.filename, this.package, this.line)
-      : super._();
+  const NewStepFile._(
+    super.import,
+    this.filename,
+    this.package,
+    this.line,
+    this.testerType,
+    this.testerName,
+  ) : super._();
 
   final String package;
   final String line;
   final String filename;
+  final String testerType;
+  final String testerName;
 
-  String get dartContent => generateStepDart(package, line);
+  String get dartContent =>
+      generateStepDart(package, line, testerType, testerName);
 }
 
 class ExistingStepFile extends StepFile {

--- a/lib/src/step_generator.dart
+++ b/lib/src/step_generator.dart
@@ -33,24 +33,42 @@ String getStepMethodName(String stepText) {
   return _camelizedString(step);
 }
 
-String getStepMethodCall(String stepLine, {List<String>? forceParams}) {
+String getStepMethodCall(
+  String stepLine,
+  String customTesterName, {
+  List<String>? forceParams,
+}) {
   final step = parseRawStepLine(stepLine);
   final parameters = [
-    'tester',
+    customTesterName,
     if (forceParams != null) ...forceParams else ...step.skip(1)
   ].join(', ');
   return '${_camelizedString(step[0])}($parameters)';
 }
 
-String generateStepDart(String package, String line) {
+String generateStepDart(
+  String package,
+  String line,
+  String testerType,
+  String customTesterName,
+) {
   final methodName = getStepMethodName(line);
-  final bddStep = _getStep(methodName, package, line);
+
+  final bddStep =
+      _getStep(methodName, package, line, testerType, customTesterName);
   return bddStep.content;
 }
 
-BddStep _getStep(String methodName, String package, String line) {
-  final factory =
-      predefinedSteps[methodName] ?? (_, __) => GenericStep(methodName, line);
+BddStep _getStep(
+  String methodName,
+  String package,
+  String line,
+  String testerType,
+  String testerName,
+) {
+  //for now, predefined steps don't support testerType
+  final factory = predefinedSteps[methodName] ??
+      (_, __) => GenericStep(methodName, line, testerType, testerName);
   return factory(package, line);
 }
 

--- a/lib/src/util/common.dart
+++ b/lib/src/util/common.dart
@@ -1,0 +1,34 @@
+import 'package:bdd_widget_test/src/bdd_line.dart';
+import 'package:collection/collection.dart';
+
+/// [parseCustomTag] Returns custom tag value or empty string if not found.
+/// Example: @testerTypeTag: PatrolTester returns `PatrolTester`
+String parseCustomTag(String rawLine, String customTag) {
+  if (rawLine.startsWith(customTag)) {
+    return rawLine.substring(customTag.length).trim();
+  }
+  return '';
+}
+
+/// [parseCustomTagFromFeatureTagLine] returns tags of [customTag] from the feature tag lines
+String parseCustomTagFromFeatureTagLine(
+  List<BddLine> featureTagLines,
+  String defaultTagValue,
+  String customTag,
+) {
+  var tagType = defaultTagValue;
+
+  final customTagLine = featureTagLines
+      .firstWhereOrNull((line) => line.rawLine.startsWith(customTag));
+
+  if (customTagLine != null) {
+    final tagOverride = parseCustomTag(
+      customTagLine.rawLine,
+      customTag,
+    );
+    if (tagOverride.isNotEmpty) {
+      tagType = tagOverride;
+    }
+  }
+  return tagType;
+}

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -3,4 +3,18 @@ const tearDownMethodName = 'bddTearDown';
 
 const testMethodNameTag = '@testMethodName:';
 
+/// [testerTypeTag] to specify the tester type to use for the test.
+/// The default testerTypeTag value is `WidgetTester`.
+/// should be on the top level of a feature file or inside build.yaml options
+const testerTypeTag = '@testerType:';
+
+/// [testerNameTag] specifies the tester name to use, the default value is tester
+/// should be on the top level of a feature file or inside build.yaml options
+const testerNameTag = '@testerName:';
+
+/// [scenarioParamsTag] can be used to filter custom parameters for
+/// scenario functions for example: @scenarioParams: skip: false, timeout: Timeout(Duration(seconds: 1))
+/// because some test packaages like `patrol` support this.
+const scenarioParamsTag = '@scenarioParams:';
+
 const testFolderName = 'test';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bdd_widget_test
 description: A BDD-style widget testing library. Generates Flutter widget tests from *.feature files.
-version: 1.6.0
+version: 1.6.1
 homepage: https://github.com/olexale/bdd_widget_test
 
 environment:

--- a/test/custom_scenario_params_test.dart
+++ b/test/custom_scenario_params_test.dart
@@ -1,0 +1,46 @@
+import 'package:bdd_widget_test/src/feature_file.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Feature Custom Scenario Parameters using tag only', () {
+    const featureFile = '''
+Feature: Testing feature 
+  @scenarioParams: skip: false, timeout: Timeout(Duration(seconds: 1))
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      await theAppIsRunningWithPatrol(tester);
+    },
+     skip: false,
+     timeout: Timeout(Duration(seconds: 1)),
+     );
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+}

--- a/test/custom_tester_name_test.dart
+++ b/test/custom_tester_name_test.dart
@@ -1,0 +1,82 @@
+import 'package:bdd_widget_test/src/feature_file.dart';
+import 'package:bdd_widget_test/src/generator_options.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Feature Custom Tester name using tag', () {
+    const featureFile = '''
+@testerName: helloTester
+Feature: Testing feature 
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (helloTester) async {
+      await theAppIsRunningWithPatrol(helloTester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+  test('Feature Custom Tester name using generator options', () {
+    const featureFile = '''
+Feature: Testing feature 
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (helloTester) async {
+      await theAppIsRunningWithPatrol(helloTester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+      generatorOptions: const GeneratorOptions(testerName: 'helloTester'),
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+}

--- a/test/custom_tester_type_test.dart
+++ b/test/custom_tester_type_test.dart
@@ -1,0 +1,84 @@
+import 'package:bdd_widget_test/src/feature_file.dart';
+import 'package:bdd_widget_test/src/generator_options.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Feature Custom Tester Type using tag', () {
+    const featureFile = '''
+@testerType: PatrolIntegrationTester
+Feature: Testing feature 
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      await theAppIsRunningWithPatrol(tester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+
+  test('Feature Custom Tester Type using generator options', () {
+    const featureFile = '''
+Feature: Testing feature 
+  Scenario: Testing scenario
+    Given the app is running with patrol
+
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running_with_patrol.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      await theAppIsRunningWithPatrol(tester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+      isIntegrationTest: true,
+      generatorOptions:
+          const GeneratorOptions(testerType: 'PatrolIntegrationTester'),
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+}


### PR DESCRIPTION
### Feature Request:

Based on the issue #44, some setup steps like the background (`bddSetup`) don't use the `testMethodName` provided by users via either tag in the `.feature` files or `build.yaml` file. So this PR resolves that and other scenarios:

- Sometimes users may not wish to use `integration_test` or `flutter_test` directly for their tests, they may choose to use other packages like [Patrol](https://pub.dev/packages/patrol) or [convenient_test](https://pub.dev/packages/convenient_test) and take advantage of this feature to pass their custom tester type, name or even the scenario parameters. 

- Also this PR addresses this [patrol limitation to use BDD](https://github.com/leancodepl/patrol/issues/1160) 

It's cool and nice to have for more feasibility 😉 🍷 


