### PR TITLE
feat: For steps with example have column names for parameters

### DIFF
--- a/lib/src/step/generic_step.dart
+++ b/lib/src/step/generic_step.dart
@@ -30,7 +30,7 @@ Future<void> $methodName($testerType $customTesterName${_getMethodParameters(raw
     if (params.isNotEmpty) {
       return params
           .mapIndexed(
-            (index, p) => ', dynamic param${index + 1}',
+            (index, p) => ', ${_getGenericParameterType(p)} param${index + 1}',
           )
           .join();
     }
@@ -41,5 +41,19 @@ Future<void> $methodName($testerType $customTesterName${_getMethodParameters(raw
     }
 
     return '';
+  }
+
+  String _getGenericParameterType(String parameter) {
+    if (parameter == 'true' || parameter == 'false') {
+      return 'bool';
+    }
+    if (num.tryParse(parameter) != null) {
+      return 'num';
+    }
+    if ((parameter.startsWith('"') && parameter.endsWith('"')) ||
+        (parameter.startsWith("'") && parameter.endsWith("'"))) {
+      return 'String';
+    }
+    return 'dynamic';
   }
 }

--- a/test/scenario_outline_step_test.dart
+++ b/test/scenario_outline_step_test.dart
@@ -18,7 +18,7 @@ Feature: Testing feature
     const expectedStep = '''
 import 'package:flutter_test/flutter_test.dart';
 
-Future<void> thereAreCucumbers(WidgetTester tester, dynamic param1) async {
+Future<void> thereAreCucumbers(WidgetTester tester, dynamic start) async {
   throw UnimplementedError();
 }
 ''';

--- a/test/step/generic_step_test.dart
+++ b/test/step/generic_step_test.dart
@@ -36,13 +36,13 @@ Future<void> iInvokeTest(WidgetTester tester) async {
     const featureFile = '''
 Feature: Testing feature
     Scenario: Testing scenario
-        When I invoke {0} test with {Some} parameter
+        When I invoke {0} test with {Some} parameter and {true} parameter and {'value'} parameter
     ''';
 
     const expectedSteps = '''
 import 'package:flutter_test/flutter_test.dart';
 
-Future<void> iInvokeTestWithParameter(WidgetTester tester, dynamic param1, dynamic param2) async {
+Future<void> iInvokeTestWithParameterAndParameterAndParameter(WidgetTester tester, num param1, dynamic param2, bool param3, String param4) async {
   throw UnimplementedError();
 }
 ''';


### PR DESCRIPTION
- [x] All tests passed

Add the possibility of having the name of the column rather than `param1` in the case of a step with examples.

Is it possible that in `<>` there are only numbers (like `<12.3>`)?

```feature
Feature: Testing feature
  Scenario: eating
    Given there are <number> cucumbers

    Examples:
      | number |
      |   12   |
      |   20   |
```
Before:
```dart
import 'package:flutter_test/flutter_test.dart';

Future<void> thereAreCucumbers(WidgetTester tester, dynamic param1) async {
  throw UnimplementedError();
}
```

After:
```dart
import 'package:flutter_test/flutter_test.dart';

Future<void> thereAreCucumbers(WidgetTester tester, dynamic number) async {
  throw UnimplementedError();
}
```