### PR TITLE
fix: Changed 'Scenarios' to 'Scenarios:' for consistency with other markers

### DIFF
--- a/lib/src/bdd_line.dart
+++ b/lib/src/bdd_line.dart
@@ -62,7 +62,7 @@ const scenarioMarkers = ['Scenario:', 'Example:'];
 const scenarioOutlineMarkers = ['Scenario Outline:'];
 const stepMarkers = ['Given', 'When', 'Then', 'And', 'But'];
 const examplesMarkers = ['|'];
-const examplesTitleMarkers = ['Examples:', 'Scenarios'];
+const examplesTitleMarkers = ['Examples:', 'Scenarios:'];
 
 String _removeLinePrefix(String rawLine) {
   final lines = rawLine.split(' ');

--- a/test/scenario_outline_test.dart
+++ b/test/scenario_outline_test.dart
@@ -57,7 +57,7 @@ Feature: Testing feature
   Scenario Outline: params
     Given there are mixed <int> <String> <Custom> parameters
 
-    Examples:
+    Scenarios:
       | int   | String  | Custom     |
       |  12   |   '5'   |  Icons.add |
       |  '20' |   5.0   |   MyClass  |


### PR DESCRIPTION
`Scenarios` to `Scenarios:` for `examplesTitleMarkers` and Change `Examples:` to `Scenarios:` in one test