### PR TITLE
Create world

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,47 @@ targets:
           testerType: PatrolIntegrationTester
 ```
 
+### How to pass a state between steps?
+
+You may use the world functionality. To activate it add the `addWorld` parameter to the yaml:
+```yaml
+targets:
+  $default:
+    builders:
+      bdd_widget_test|featureBuilder:
+        options:
+          addWorld: true
+```
+This will add a world object to the generated feature files, step files and hook files. Do note that it will not regenerate the step files you already have, so you might need to add the world parameter there manually.
+The world parameter holds a key value map that you can store state in that travels through the scenario. This means you could translate the following feature file in these steps:
+```gherkin
+ Scenario: Input login screen
+        Given I have a user {'Tom'} {'password'}
+        When When I enter {'Tom'} into {1} input field
+        Then Input {1} should contain my user's username
+```
+
+```dart
+/// Usage: I have a user {"Tom"} {"password"}
+Future<void> iHaveAUser(WidgetTester tester, String param1, String param2, World world) async {
+  world.parameters.putIfAbsent("userName", () => param1);
+  world.parameters.putIfAbsent("password", () => param2);
+}
+```
+
+```dart
+/// Usage: Input {1} should contain my user's username
+Future<void> inputShouldContainMyUsersUsername(WidgetTester tester, int index, World world) async {
+  final textField = find.byType(TextField).at(index);
+  final widget = tester.firstWidget<TextField>(textField);
+
+  final userName = world.parameters["userName"];
+
+  expect(widget.controller?.text, equals(userName));
+}
+```
+
+
 ## Contributing
 
 If you find a bug or would like to request a new feature, just [open an issue](https://github.com/olexale/bdd_widget_test/issues/new). Your contributions are always welcome!

--- a/lib/bdd_widget_test.dart
+++ b/lib/bdd_widget_test.dart
@@ -44,7 +44,10 @@ class FeatureBuilder implements Builder {
 
     final hookFile = feature.hookFile;
     if (hookFile != null) {
-      await createFileRecursively(hookFile.fileName, hookFileContent);
+      await createFileRecursively(
+        hookFile.fileName,
+        createHooksFileContent(options.addWorld),
+      );
     }
   }
 

--- a/lib/src/data_table_parser.dart
+++ b/lib/src/data_table_parser.dart
@@ -74,7 +74,7 @@ Iterable<BddLine> _createDataTableFromExamples({
     dataTable.add(lines[++index]);
   } while (
       index + 1 < lines.length && lines[index + 1].type == LineType.examples);
-  final data = generateScenariosFromScenaioOutline([
+  final data = generateScenariosFromScenarioOutline([
     // pretend to be an Example section to re-use some logic
     BddLine.fromValue(LineType.exampleTitle, ''),
     ...dataTable,

--- a/lib/src/feature_file.dart
+++ b/lib/src/feature_file.dart
@@ -78,6 +78,7 @@ class FeatureFile {
         _testerName,
         isIntegrationTest,
         hookFile,
+        generatorOptions.addWorld,
       );
 
   List<StepFile> getStepFiles() => _stepFiles;

--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -15,6 +15,7 @@ String generateFeatureDart(
   String testerName,
   bool isIntegrationTest,
   HookFile? hookFile,
+  bool addWorld,
 ) {
   final sb = StringBuffer();
   sb.writeln('// GENERATED CODE - DO NOT MODIFY BY HAND');
@@ -52,6 +53,9 @@ String generateFeatureDart(
   }
   if (hasBddDataTable(lines)) {
     sb.writeln("import 'package:bdd_widget_test/data_table.dart' as bdd;");
+  }
+  if (addWorld) {
+    sb.writeln("import 'package:bdd_widget_test/world.dart';");
   }
   sb.writeln("import 'package:flutter/material.dart';");
   sb.writeln("import 'package:flutter_test/flutter_test.dart';");
@@ -104,12 +108,14 @@ String generateFeatureDart(
       feature,
       testerTypeOverride,
       testerNameOverride,
+      addWorld,
     );
     final hasAfter = _parseAfter(
       sb,
       feature,
       testerTypeOverride,
       testerNameOverride,
+      addWorld,
     );
 
     if (hookFile != null) {
@@ -118,12 +124,14 @@ String generateFeatureDart(
         hookClass,
         testerTypeOverride,
         testerNameOverride,
+        addWorld,
       );
       _parseAfterHook(
         sb,
         hookClass,
         testerTypeOverride,
         testerNameOverride,
+        addWorld,
       );
     }
 
@@ -135,6 +143,7 @@ String generateFeatureDart(
       hookFile != null,
       featureTestMethodNameOverride,
       testerNameOverride,
+      addWorld,
     );
   }
   sb.writeln('}');
@@ -146,12 +155,13 @@ void _parseAfterHook(
   String hookClass,
   String testerType,
   String testerName,
+  bool addWorld,
 ) {
   sb.writeln(
-    '    Future<void> $tearDownHookName(String title, bool $testSuccessVariableName, [List<String>? tags]) async {',
+    '    Future<void> $tearDownHookName(String title, bool $testSuccessVariableName,${addWorld ? '$worldParameter, ' : ''} [List<String>? tags]) async {',
   );
   sb.writeln(
-    '      await $hookClass.$tearDownHookName(title, $testSuccessVariableName, tags);',
+    '      await $hookClass.$tearDownHookName(title, $testSuccessVariableName, ${addWorld ? '$worldVarName, ' : ''}tags);',
   );
   sb.writeln('    }');
 }
@@ -161,12 +171,13 @@ void _parseBeforeHook(
   String hookClass,
   String testerType,
   String testerName,
+  bool addWorld,
 ) {
   sb.writeln(
-    '    Future<void> $setUpHookName(String title, [List<String>? tags]) async {',
+    '    Future<void> $setUpHookName(String title, ${addWorld ? '$worldParameter, ' : ''}[List<String>? tags]) async {',
   );
   sb.writeln(
-    '      await $hookClass.$setUpHookName(title, tags);',
+    '      await $hookClass.$setUpHookName(title, ${addWorld ? '$worldVarName, ' : ''}tags);',
   );
   sb.writeln('    }');
 }
@@ -191,6 +202,7 @@ bool _parseBackground(
   List<BddLine> lines,
   String testerType,
   String testerName,
+  bool addWorld,
 ) =>
     _parseSetup(
       sb,
@@ -199,6 +211,7 @@ bool _parseBackground(
       setUpMethodName,
       testerType,
       testerName,
+      addWorld,
     );
 
 bool _parseAfter(
@@ -206,6 +219,7 @@ bool _parseAfter(
   List<BddLine> lines,
   String testerType,
   String testerName,
+  bool addWorld,
 ) =>
     _parseSetup(
       sb,
@@ -214,6 +228,7 @@ bool _parseAfter(
       tearDownMethodName,
       testerType,
       testerName,
+      addWorld,
     );
 
 bool _parseSetup(
@@ -223,6 +238,7 @@ bool _parseSetup(
   String title,
   String testerType,
   String testerName,
+  bool addWorld,
 ) {
   final flattenDataTables = replaceDataTables(
     lines.skipWhile((line) => line.type == LineType.tag).toList(),
@@ -230,12 +246,14 @@ bool _parseSetup(
   var offset =
       flattenDataTables.indexWhere((element) => element.type == elementType);
   if (offset != -1) {
-    sb.writeln('    Future<void> $title($testerType $testerName) async {');
+    sb.writeln(
+      '    Future<void> $title($testerType $testerName${addWorld ? ', $worldParameter' : ''}) async {',
+    );
     offset++;
     while (flattenDataTables[offset].type == LineType.step ||
         flattenDataTables[offset].type == LineType.dataTableStep) {
       sb.writeln(
-        '      await ${getStepMethodCall(flattenDataTables[offset].value, testerName)};',
+        '      await ${getStepMethodCall(flattenDataTables[offset].value, testerName, addWorld)};',
       );
       offset++;
     }
@@ -252,6 +270,7 @@ void _parseFeature(
   bool hasHooks,
   String testMethodName,
   String testerName,
+  bool addWorld,
 ) {
   final scenarios = _splitScenarios(
     feature.skipWhile((value) => !_isNewScenario(value.type)).toList(),
@@ -302,6 +321,7 @@ void _parseFeature(
             .map((line) => line.rawLine.substring('@'.length))
             .toList(),
         scenarioParams,
+        addWorld,
       );
     }
   }

--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -224,14 +224,18 @@ bool _parseSetup(
   String testerType,
   String testerName,
 ) {
-  var offset = lines.indexWhere((element) => element.type == elementType);
+  final flattenDataTables = replaceDataTables(
+    lines.skipWhile((line) => line.type == LineType.tag).toList(),
+  ).toList();
+  var offset =
+      flattenDataTables.indexWhere((element) => element.type == elementType);
   if (offset != -1) {
     sb.writeln('    Future<void> $title($testerType $testerName) async {');
     offset++;
-    while (lines[offset].type == LineType.step ||
-        lines[offset].type == LineType.dataTableStep) {
+    while (flattenDataTables[offset].type == LineType.step ||
+        flattenDataTables[offset].type == LineType.dataTableStep) {
       sb.writeln(
-        '      await ${getStepMethodCall(lines[offset].value, testerName)};',
+        '      await ${getStepMethodCall(flattenDataTables[offset].value, testerName)};',
       );
       offset++;
     }
@@ -272,7 +276,7 @@ void _parseFeature(
     ).toList();
     final scenariosToParse = flattenDataTables.first.type == LineType.scenario
         ? [flattenDataTables]
-        : generateScenariosFromScenaioOutline(flattenDataTables);
+        : generateScenariosFromScenarioOutline(flattenDataTables);
 
     for (final s in scenariosToParse) {
       parseScenario(

--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -158,7 +158,7 @@ void _parseAfterHook(
   bool addWorld,
 ) {
   sb.writeln(
-    '    Future<void> $tearDownHookName(String title, bool $testSuccessVariableName,${addWorld ? '$worldParameter, ' : ''} [List<String>? tags]) async {',
+    '    Future<void> $tearDownHookName(String title, bool $testSuccessVariableName, ${addWorld ? '$worldParameter, ' : ''}[List<String>? tags]) async {',
   );
   sb.writeln(
     '      await $hookClass.$tearDownHookName(title, $testSuccessVariableName, ${addWorld ? '$worldVarName, ' : ''}tags);',

--- a/lib/src/generator_options.dart
+++ b/lib/src/generator_options.dart
@@ -17,6 +17,7 @@ class GeneratorOptions {
     String? testerName,
     bool? addHooks,
     String? hookFolderName,
+    bool? addWorld,
     this.include,
   })  : stepFolder = stepFolderName ?? _stepFolderName,
         testMethodName = testMethodName ?? _defaultTestMethodName,
@@ -24,6 +25,7 @@ class GeneratorOptions {
         testerName = testerName ?? _defaultTesterName,
         addHooks = addHooks ?? false,
         hookFolderName = hookFolderName ?? _hookFolderName,
+        addWorld = addWorld ?? false,
         externalSteps = externalSteps ?? const [];
 
   factory GeneratorOptions.fromMap(Map<String, dynamic> json) =>
@@ -35,6 +37,7 @@ class GeneratorOptions {
         stepFolderName: json['stepFolderName'] as String?,
         addHooks: json['addHooks'] as bool?,
         hookFolderName: json['hookFolderName'] as String?,
+        addWorld: json['addWorld'] as bool?,
         include: json['include'] is String
             ? [(json['include'] as String)]
             : (json['include'] as List?)?.cast<String>(),
@@ -46,6 +49,7 @@ class GeneratorOptions {
   final String testerName;
   final bool addHooks;
   final String hookFolderName;
+  final bool addWorld;
   final List<String>? include;
   final List<String> externalSteps;
 }
@@ -85,6 +89,7 @@ GeneratorOptions readFromUri(Uri uri) {
     stepFolderName: doc['stepFolderName'] as String?,
     addHooks: doc['addHooks'] as bool?,
     hookFolderName: doc['hookFolderName'] as String?,
+    addWorld: doc['addWorld'] as bool?,
     include: doc['include'] is String
         ? [(doc['include'] as String)]
         : (doc['include'] as YamlList?)?.value.cast<String>(),
@@ -107,5 +112,6 @@ GeneratorOptions merge(GeneratorOptions a, GeneratorOptions b) =>
       hookFolderName: a.hookFolderName != _hookFolderName
           ? a.hookFolderName
           : b.hookFolderName,
+      addWorld: a.addWorld || b.addWorld,
       include: b.include,
     );

--- a/lib/src/hook_file.dart
+++ b/lib/src/hook_file.dart
@@ -50,7 +50,7 @@ class HookFile {
 String createHooksFileContent(bool addWorld) {
   return '''
 import 'dart:async';
-${addWorld ? "\nimport 'package:bdd_widget_test/world.dart';\n" : ''}
+${addWorld ? "import 'package:bdd_widget_test/world.dart';\n" : ''}
 abstract class Hooks {
   const Hooks._();
   

--- a/lib/src/hook_file.dart
+++ b/lib/src/hook_file.dart
@@ -47,30 +47,35 @@ class HookFile {
   final String import;
 }
 
-const String hookFileContent = '''
+String createHooksFileContent(bool addWorld) {
+  return '''
 import 'dart:async';
-
+${addWorld ? "\nimport 'package:bdd_widget_test/world.dart';\n" : ''}
 abstract class Hooks {
   const Hooks._();
   
-  static FutureOr<void> beforeEach(String title, [List<String>? tags]) {
-    // Add logic for beforeEach
+  static FutureOr<void> $setUpHookName(
+    String title,${addWorld ? "\n    $worldParameter," : ""} [
+    List<String>? tags,
+    ]) {
+    // Add logic for $setUpHookName
   }
   
-  static FutureOr<void> beforeAll() {
-    // Add logic for beforeAll
+  static FutureOr<void> $setUpAllHookName() {
+    // Add logic for $setUpAllHookName
   }
   
-  static FutureOr<void> afterEach(
+  static FutureOr<void> $tearDownHookName(
     String title,
-    bool success, [
+    bool success,${addWorld ? "\n    $worldParameter," : ""} [
     List<String>? tags,
   ]) {
-    // Add logic for afterEach
+    // Add logic for $tearDownHookName
   }
   
-  static FutureOr<void> afterAll() {
-    // Add logic for afterAll
+  static FutureOr<void> $tearDownAllHookName() {
+    // Add logic for $tearDownAllHookName
   }
 }
 ''';
+}

--- a/lib/src/scenario_generator.dart
+++ b/lib/src/scenario_generator.dart
@@ -55,7 +55,8 @@ void parseScenario(
     sb.writeln('      } finally {');
     if (hasTearDown) {
       sb.writeln(
-          '        await $tearDownMethodName($testerName${addWorld ? ', $worldVarName' : ''});');
+        '        await $tearDownMethodName($testerName${addWorld ? ', $worldVarName' : ''});',
+      );
     }
     if (hasHooks) {
       sb.writeln('        await $tearDownHookName(');

--- a/lib/src/scenario_generator.dart
+++ b/lib/src/scenario_generator.dart
@@ -13,28 +13,36 @@ void parseScenario(
   String testerName,
   List<String> tags,
   String scenarioParams,
+  bool addWorld,
 ) {
   sb.writeln(
     "    $testMethodName('''$scenarioTitle''', ($testerName) async {",
   );
+  if (addWorld) {
+    sb.writeln('      final $worldParameter = $worldTypeName.empty();');
+  }
   if (hasHooks) {
-    sb.writeln('      var $testSuccessVariableName = true;');
+    sb.writeln('      bool $testSuccessVariableName = true;');
   }
   if (hasTearDown || hasHooks) {
     sb.writeln('      try {');
   }
-  final spaces = hasTearDown ? '        ' : '      ';
+  final spaces = hasTearDown || hasHooks ? '        ' : '      ';
   if (hasHooks) {
     sb.writeln(
-      "${spaces}await $setUpHookName('''$scenarioTitle''' ${tags.isNotEmpty ? ', ${tagsToString(tags)}' : ''});",
+      "${spaces}await $setUpHookName('''$scenarioTitle'''${addWorld ? ', $worldVarName' : ''}${tags.isNotEmpty ? ', ${tagsToString(tags)}' : ''});",
     );
   }
   if (hasSetUp) {
-    sb.writeln('${spaces}await $setUpMethodName($testerName);');
+    sb.writeln(
+      '${spaces}await $setUpMethodName($testerName${addWorld ? ', $worldVarName' : ''});',
+    );
   }
 
   for (final step in scenario) {
-    sb.writeln('${spaces}await ${getStepMethodCall(step.value, testerName)};');
+    sb.writeln(
+      '${spaces}await ${getStepMethodCall(step.value, testerName, addWorld)};',
+    );
   }
 
   if (hasHooks) {
@@ -46,12 +54,16 @@ void parseScenario(
   if (hasTearDown | hasHooks) {
     sb.writeln('      } finally {');
     if (hasTearDown) {
-      sb.writeln('        await $tearDownMethodName($testerName);');
+      sb.writeln(
+          '        await $tearDownMethodName($testerName${addWorld ? ', $worldVarName' : ''});');
     }
     if (hasHooks) {
       sb.writeln('        await $tearDownHookName(');
       sb.writeln("          '''$scenarioTitle''',");
       sb.writeln('          $testSuccessVariableName,');
+      if (addWorld) {
+        sb.writeln('          $worldVarName,');
+      }
       if (tags.isNotEmpty) {
         sb.writeln('          ${tagsToString(tags)},');
       }

--- a/lib/src/scenario_generator.dart
+++ b/lib/src/scenario_generator.dart
@@ -77,7 +77,7 @@ String tagsToString(List<String> tags) {
   return "['${tags.join("', '")}']";
 }
 
-List<List<BddLine>> generateScenariosFromScenaioOutline(
+List<List<BddLine>> generateScenariosFromScenarioOutline(
   List<BddLine> scenario,
 ) {
   final examples = _getExamples(scenario);

--- a/lib/src/step/generic_step.dart
+++ b/lib/src/step/generic_step.dart
@@ -1,6 +1,7 @@
 import 'package:bdd_widget_test/src/regex.dart';
 import 'package:bdd_widget_test/src/step/bdd_step.dart';
 import 'package:bdd_widget_test/src/step_generator.dart';
+import 'package:bdd_widget_test/src/util/constants.dart';
 import 'package:collection/collection.dart';
 
 class GenericStep implements BddStep {
@@ -10,6 +11,7 @@ class GenericStep implements BddStep {
     this.testerType,
     this.customTesterName,
     this.hasDataTable,
+    this.addWorld,
   );
 
   final String rawLine;
@@ -17,15 +19,17 @@ class GenericStep implements BddStep {
   final String testerType;
   final String customTesterName;
   final bool hasDataTable;
+  final bool addWorld;
 
   @override
   String get content =>
       '${hasDataTable ? "import 'package:bdd_widget_test/data_table.dart' as bdd;\n" : ''}'
+      '${addWorld ? "import 'package:bdd_widget_test/world.dart';\n" : ''}'
       '''
 import 'package:flutter_test/flutter_test.dart';
 
 /// Usage: $rawLine
-Future<void> $methodName($testerType $customTesterName${_getMethodParameters(rawLine, hasDataTable)}) async {
+Future<void> $methodName($testerType $customTesterName${_getMethodParameters(rawLine, hasDataTable)}${addWorld ? ", $worldParameter" : ""}) async {
   throw UnimplementedError();
 }
 ''';

--- a/lib/src/step_file.dart
+++ b/lib/src/step_file.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 
 abstract class StepFile {
   const StepFile._(this.import);
+
   final String import;
 
   static StepFile create(
@@ -44,6 +45,7 @@ abstract class StepFile {
         testerTypeTagValue,
         testerNameTagValue,
         bddLine.type == LineType.dataTableStep,
+        generatorOptions.addWorld,
       );
     }
 
@@ -60,6 +62,7 @@ abstract class StepFile {
       testerTypeTagValue,
       testerNameTagValue,
       bddLine.type == LineType.dataTableStep,
+      generatorOptions.addWorld,
     );
   }
 }
@@ -73,6 +76,7 @@ class NewStepFile extends StepFile {
     this.testerType,
     this.testerName,
     this.hasDataTable,
+    this.addWorld,
   ) : super._();
 
   final String package;
@@ -81,12 +85,15 @@ class NewStepFile extends StepFile {
   final String testerType;
   final String testerName;
   final bool hasDataTable;
+  final bool addWorld;
+
   String get dartContent => generateStepDart(
         package,
         line,
         testerType,
         testerName,
         hasDataTable,
+        addWorld,
       );
 }
 

--- a/lib/src/step_generator.dart
+++ b/lib/src/step_generator.dart
@@ -20,6 +20,7 @@ import 'package:bdd_widget_test/src/step/i_tap_icon.dart';
 import 'package:bdd_widget_test/src/step/i_tap_text.dart';
 import 'package:bdd_widget_test/src/step/i_wait.dart';
 import 'package:bdd_widget_test/src/step/the_app_is_running_step.dart';
+import 'package:bdd_widget_test/src/util/constants.dart';
 import 'package:bdd_widget_test/src/util/string_utils.dart';
 import 'package:diacritic/diacritic.dart';
 
@@ -35,13 +36,15 @@ String getStepMethodName(String stepText) {
 
 String getStepMethodCall(
   String stepLine,
-  String customTesterName, {
+  String customTesterName,
+  bool addWorld, {
   List<String>? forceParams,
 }) {
   final step = parseRawStepLine(stepLine);
   final parameters = [
     customTesterName,
     if (forceParams != null) ...forceParams else ...step.skip(1),
+    if (addWorld) worldVarName,
   ].join(', ');
   return '${_camelizedString(step[0])}($parameters)';
 }
@@ -52,17 +55,12 @@ String generateStepDart(
   String testerType,
   String customTesterName,
   bool hasDataTable,
+  bool addWorld,
 ) {
   final methodName = getStepMethodName(line);
 
-  final bddStep = _getStep(
-    methodName,
-    package,
-    line,
-    testerType,
-    customTesterName,
-    hasDataTable,
-  );
+  final bddStep = _getStep(methodName, package, line, testerType,
+      customTesterName, hasDataTable, addWorld);
   return bddStep.content;
 }
 
@@ -73,6 +71,7 @@ BddStep _getStep(
   String testerType,
   String testerName,
   bool hasDataTable,
+  bool addWorld,
 ) {
   //for now, predefined steps don't support testerType
   final factory = predefinedSteps[methodName] ??
@@ -82,6 +81,7 @@ BddStep _getStep(
             testerType,
             testerName,
             hasDataTable,
+            addWorld,
           );
   return factory(package, line);
 }

--- a/lib/src/step_generator.dart
+++ b/lib/src/step_generator.dart
@@ -59,8 +59,15 @@ String generateStepDart(
 ) {
   final methodName = getStepMethodName(line);
 
-  final bddStep = _getStep(methodName, package, line, testerType,
-      customTesterName, hasDataTable, addWorld);
+  final bddStep = _getStep(
+    methodName,
+    package,
+    line,
+    testerType,
+    customTesterName,
+    hasDataTable,
+    addWorld,
+  );
   return bddStep.content;
 }
 

--- a/lib/src/util/constants.dart
+++ b/lib/src/util/constants.dart
@@ -9,6 +9,11 @@ const tearDownHookName = 'afterEach';
 const setUpAllHookName = 'beforeAll';
 const tearDownAllHookName = 'afterAll';
 
+const worldVarName = 'world';
+const worldTypeName = 'World';
+
+const worldParameter = '$worldTypeName $worldVarName';
+
 //https://api.flutter.dev/flutter/flutter_test/setUpAll.html
 const setUpAllCallbackName = 'setUpAll';
 

--- a/lib/world.dart
+++ b/lib/world.dart
@@ -1,0 +1,7 @@
+class World {
+  World({required this.parameters});
+
+  World.empty() : parameters = {};
+
+  final Map<String, dynamic> parameters;
+}

--- a/test/data_tables_test.dart
+++ b/test/data_tables_test.dart
@@ -317,4 +317,58 @@ void main() {
 
     expect(feature.dartContent, expectedFeatureDart);
   });
+
+  test('Cucumber data table in background', () {
+    const featureFile = '''
+Feature: Testing feature
+  
+  Background:
+    Given the following songs
+    | artist           | title                |
+    | 'The Beatles'    | 'Let It Be'          |
+    | 'Camel'          | 'Slow yourself down' |
+
+  Scenario: Testing scenario
+    Given I wait
+    And the following users exist <name> <twitter>
+    | name            | twitter       |
+    | 'Oleksandr'     | '@olexale'    |
+    | 'Flutter'       | '@FlutterDev' |
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:bdd_widget_test/data_table.dart' as bdd;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import './step/the_following_songs.dart';
+import './step/i_wait.dart';
+import './step/the_following_users_exist.dart';
+
+void main() {
+  group(\'\'\'Testing feature\'\'\', () {
+    Future<void> bddSetUp(WidgetTester tester) async {
+      await theServerAlwaysReturnErrors(tester, const bdd.DataTable([[artist, title], ['The Beatles', 'Let It Be'], ['Camel', 'Slow yourself down']]));
+    }
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      await bddSetUp(tester);
+      await iWait(tester);
+      await theFollowingUsersExist(tester, 'Oleksandr', '@olexale');
+      await theFollowingUsersExist(tester, 'Flutter', '@FlutterDev');
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+    );
+
+    expect(feature.dartContent, expectedFeatureDart);
+  });
 }

--- a/test/data_tables_test.dart
+++ b/test/data_tables_test.dart
@@ -351,13 +351,71 @@ import './step/the_following_users_exist.dart';
 void main() {
   group(\'\'\'Testing feature\'\'\', () {
     Future<void> bddSetUp(WidgetTester tester) async {
-      await theServerAlwaysReturnErrors(tester, const bdd.DataTable([[artist, title], ['The Beatles', 'Let It Be'], ['Camel', 'Slow yourself down']]));
+      await theFollowingSongs(tester, const bdd.DataTable([[artist, title], ['The Beatles', 'Let It Be'], ['Camel', 'Slow yourself down']]));
     }
     testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
       await bddSetUp(tester);
       await iWait(tester);
       await theFollowingUsersExist(tester, 'Oleksandr', '@olexale');
       await theFollowingUsersExist(tester, 'Flutter', '@FlutterDev');
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: featureFile,
+    );
+
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+
+  test('Cucumber data table in after', () {
+    const featureFile = '''
+Feature: Testing feature
+  
+  After:
+    Given I wait
+    And the following users exist <name> <twitter>
+    | name            | twitter       |
+    | 'Oleksandr'     | '@olexale'    |
+    | 'Flutter'       | '@FlutterDev' |
+
+  Scenario: Testing scenario
+    Given the following songs
+    | artist           | title                |
+    | 'The Beatles'    | 'Let It Be'          |
+    | 'Camel'          | 'Slow yourself down' |
+   
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:bdd_widget_test/data_table.dart' as bdd;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import './step/i_wait.dart';
+import './step/the_following_users_exist.dart';
+import './step/the_following_songs.dart';
+
+void main() {
+  group(\'\'\'Testing feature\'\'\', () {
+    Future<void> bddTearDown(WidgetTester tester) async {
+      await iWait(tester);
+      await theFollowingUsersExist(tester, 'Oleksandr', '@olexale');
+      await theFollowingUsersExist(tester, 'Flutter', '@FlutterDev');
+    }
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      try {
+        await theFollowingSongs(tester, const bdd.DataTable([[artist, title], ['The Beatles', 'Let It Be'], ['Camel', 'Slow yourself down']]));
+      } finally {
+        await bddTearDown(tester);
+      }
     });
   });
 }

--- a/test/feature_generator_test.dart
+++ b/test/feature_generator_test.dart
@@ -92,10 +92,10 @@ hookFolderName: hooksFolder
         '      await Hooks.afterEach(title, success, tags);\n'
         '    }\n'
         "    customName('''Testing scenario''', (tester) async {\n"
-        '      var success = true;\n'
+        '      bool success = true;\n'
         '      try {\n'
-        "      await beforeEach('''Testing scenario''' );\n"
-        '      await theAppIsRunning(tester);\n'
+        "        await beforeEach('''Testing scenario''');\n"
+        '        await theAppIsRunning(tester);\n'
         '      } on TestFailure {\n'
         '        success = false;\n'
         '        rethrow;\n'

--- a/test/feature_with_hooks_test.dart
+++ b/test/feature_with_hooks_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'util/testing_data.dart';
 
 void main() {
-  test('integration-related lines are added', () {
+  test('Hook related lines are added', () {
     const expectedFeatureDart = '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: unused_import, directives_ordering
@@ -32,10 +32,10 @@ void main() {
       await Hooks.afterEach(title, success, tags);
     }
     testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
-      var success = true;
+      bool success = true;
       try {
-      await beforeEach(\'\'\'Testing scenario\'\'\' );
-      await theAppIsRunning(tester);
+        await beforeEach(\'\'\'Testing scenario\'\'\');
+        await theAppIsRunning(tester);
       } on TestFailure {
         success = false;
         rethrow;

--- a/test/full_set_test.dart
+++ b/test/full_set_test.dart
@@ -29,6 +29,7 @@ Feature: Counter 2
 // ignore_for_file: unused_import, directives_ordering
 
 @Tags(['customFeatureTag'])
+import 'package:bdd_widget_test/world.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -47,55 +48,58 @@ void main() {
   });
 
   group(\'\'\'Counter\'\'\', () {
-    Future<void> bddSetUp(WidgetTester tester) async {
-      await theAppIsRunning(tester);
+    Future<void> bddSetUp(WidgetTester tester, World world) async {
+      await theAppIsRunning(tester, world);
     }
-    Future<void> bddTearDown(WidgetTester tester) async {
-      await _iDoNotSeeText(tester, '42');
+    Future<void> bddTearDown(WidgetTester tester, World world) async {
+      await _iDoNotSeeText(tester, '42', world);
     }
-    Future<void> beforeEach(String title, [List<String>? tags]) async {
-      await Hooks.beforeEach(title, tags);
+    Future<void> beforeEach(String title, World world, [List<String>? tags]) async {
+      await Hooks.beforeEach(title, world, tags);
     }
-    Future<void> afterEach(String title, bool success, [List<String>? tags]) async {
-      await Hooks.afterEach(title, success, tags);
+    Future<void> afterEach(String title, bool success, World world, [List<String>? tags]) async {
+      await Hooks.afterEach(title, success, world, tags);
     }
     customTestWidgets(\'\'\'Initial counter value is 0\'\'\', (tester) async {
-      var success = true;
+      final World world = World.empty();
+      bool success = true;
       try {
-        await beforeEach(\'\'\'Initial counter value is 0\'\'\' , ['customScenarioTag']);
-        await bddSetUp(tester);
-        await theAppIsRunning(tester);
-        await iRunCode(tester, 'func foo() {}; func bar() { print("hey!"); };');
-        await iSeeText(tester, '0');
+        await beforeEach(\'\'\'Initial counter value is 0\'\'\', world, ['customScenarioTag']);
+        await bddSetUp(tester, world);
+        await theAppIsRunning(tester, world);
+        await iRunCode(tester, 'func foo() {}; func bar() { print("hey!"); };', world);
+        await iSeeText(tester, '0', world);
       } on TestFailure {
         success = false;
         rethrow;
       } finally {
-        await bddTearDown(tester);
+        await bddTearDown(tester, world);
         await afterEach(
           \'\'\'Initial counter value is 0\'\'\',
           success,
+          world,
           ['customScenarioTag'],
         );
       }
     }, tags: ['customScenarioTag']);
   });
   group(\'\'\'Counter 2\'\'\', () {
-    Future<void> bddSetUp(WidgetTester tester) async {
-      await theAppIsRunning(tester);
+    Future<void> bddSetUp(WidgetTester tester, World world) async {
+      await theAppIsRunning(tester, world);
     }
-    Future<void> beforeEach(String title, [List<String>? tags]) async {
-      await Hooks.beforeEach(title, tags);
+    Future<void> beforeEach(String title, World world, [List<String>? tags]) async {
+      await Hooks.beforeEach(title, world, tags);
     }
-    Future<void> afterEach(String title, bool success, [List<String>? tags]) async {
-      await Hooks.afterEach(title, success, tags);
+    Future<void> afterEach(String title, bool success, World world, [List<String>? tags]) async {
+      await Hooks.afterEach(title, success, world, tags);
     }
     customTestWidgets(\'\'\'Initial counter value is 0\'\'\', (tester) async {
-      var success = true;
+      final World world = World.empty();
+      bool success = true;
       try {
-      await beforeEach(\'\'\'Initial counter value is 0\'\'\' );
-      await bddSetUp(tester);
-      await theAppIsRunning(tester);
+        await beforeEach(\'\'\'Initial counter value is 0\'\'\', world);
+        await bddSetUp(tester, world);
+        await theAppIsRunning(tester, world);
       } on TestFailure {
         success = false;
         rethrow;
@@ -103,6 +107,7 @@ void main() {
         await afterEach(
           \'\'\'Initial counter value is 0\'\'\',
           success,
+          world,
         );
       }
     });
@@ -124,6 +129,7 @@ void main() {
         ],
         addHooks: true,
         hookFolderName: './hooksFolder',
+        addWorld: true,
       ),
     );
     expect(feature.dartContent, expectedFeatureDart);

--- a/test/hook_file_test.dart
+++ b/test/hook_file_test.dart
@@ -1,5 +1,6 @@
 import 'package:bdd_widget_test/src/feature_file.dart';
 import 'package:bdd_widget_test/src/generator_options.dart';
+import 'package:bdd_widget_test/src/hook_file.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -27,5 +28,80 @@ void main() {
       input: '',
     );
     expect(feature.hookFile, isNull);
+  });
+
+  test('Hook file content generation ', () {
+    const expectedFileContent = '''
+import 'dart:async';
+
+abstract class Hooks {
+  const Hooks._();
+  
+  static FutureOr<void> beforeEach(
+    String title, [
+    List<String>? tags,
+    ]) {
+    // Add logic for beforeEach
+  }
+  
+  static FutureOr<void> beforeAll() {
+    // Add logic for beforeAll
+  }
+  
+  static FutureOr<void> afterEach(
+    String title,
+    bool success, [
+    List<String>? tags,
+  ]) {
+    // Add logic for afterEach
+  }
+  
+  static FutureOr<void> afterAll() {
+    // Add logic for afterAll
+  }
+}
+''';
+
+    final hookFileContent = createHooksFileContent(false);
+    expect(hookFileContent, equals(expectedFileContent));
+  });
+
+  test('Hook file content generation with world ', () {
+    const expectedFileContent = '''
+import 'dart:async';
+import 'package:bdd_widget_test/world.dart';
+
+abstract class Hooks {
+  const Hooks._();
+  
+  static FutureOr<void> beforeEach(
+    String title,
+    World world, [
+    List<String>? tags,
+    ]) {
+    // Add logic for beforeEach
+  }
+  
+  static FutureOr<void> beforeAll() {
+    // Add logic for beforeAll
+  }
+  
+  static FutureOr<void> afterEach(
+    String title,
+    bool success,
+    World world, [
+    List<String>? tags,
+  ]) {
+    // Add logic for afterEach
+  }
+  
+  static FutureOr<void> afterAll() {
+    // Add logic for afterAll
+  }
+}
+''';
+
+    final hookFileContent = createHooksFileContent(true);
+    expect(hookFileContent, equals(expectedFileContent));
   });
 }

--- a/test/world_test.dart
+++ b/test/world_test.dart
@@ -1,0 +1,192 @@
+import 'package:bdd_widget_test/src/feature_file.dart';
+import 'package:bdd_widget_test/src/generator_options.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'util/testing_data.dart';
+
+void main() {
+  test('Steps get the world parameter if it is enabled', () {
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:bdd_widget_test/world.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import './step/the_app_is_running.dart';
+
+void main() {
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      final World world = World.empty();
+      await theAppIsRunning(tester, world);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test/subdir/feature',
+      package: 'test',
+      input: minimalFeatureFile,
+      generatorOptions: const GeneratorOptions(
+        addWorld: true,
+      ),
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+
+  test('Hooks get world parameter added to them if world is enabled', () {
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:bdd_widget_test/world.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import './hook/hooks.dart';
+import './step/the_app_is_running.dart';
+
+void main() {
+  setUpAll(() async {
+    await Hooks.beforeAll();
+  });
+  tearDownAll(() async {
+    await Hooks.afterAll();
+  });
+
+  group(\'\'\'Testing feature\'\'\', () {
+    Future<void> beforeEach(String title, World world, [List<String>? tags]) async {
+      await Hooks.beforeEach(title, world, tags);
+    }
+    Future<void> afterEach(String title, bool success, World world, [List<String>? tags]) async {
+      await Hooks.afterEach(title, success, world, tags);
+    }
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      final World world = World.empty();
+      bool success = true;
+      try {
+        await beforeEach(\'\'\'Testing scenario\'\'\', world);
+        await theAppIsRunning(tester, world);
+      } on TestFailure {
+        success = false;
+        rethrow;
+      } finally {
+        await afterEach(
+          \'\'\'Testing scenario\'\'\',
+          success,
+          world,
+        );
+      }
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test/subdir/feature',
+      package: 'test',
+      input: minimalFeatureFile,
+      generatorOptions: const GeneratorOptions(
+        addHooks: true,
+        addWorld: true,
+      ),
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+
+  test('After steps get the world parameter', () {
+    const featureFile = '''
+Feature: Testing feature
+  After:
+    And the test finishes
+  Scenario: Testing scenario
+    Given the app is running
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:bdd_widget_test/world.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import './step/the_test_finishes.dart';
+import './step/the_app_is_running.dart';
+
+void main() {
+  group(\'\'\'Testing feature\'\'\', () {
+    Future<void> bddTearDown(WidgetTester tester, World world) async {
+      await theTestFinishes(tester, world);
+    }
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      final World world = World.empty();
+      try {
+        await theAppIsRunning(tester, world);
+      } finally {
+        await bddTearDown(tester, world);
+      }
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test/subdir/feature',
+      package: 'test',
+      input: featureFile,
+      generatorOptions: const GeneratorOptions(
+        addWorld: true,
+      ),
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+
+  test('Background steps get the world parameter', () {
+    const featureFile = '''
+Feature: Testing feature
+  Background:
+    Given the server always return errors
+  Scenario: Testing scenario
+    Given the app is running
+''';
+
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:bdd_widget_test/world.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import './step/the_server_always_return_errors.dart';
+import './step/the_app_is_running.dart';
+
+void main() {
+  group(\'\'\'Testing feature\'\'\', () {
+    Future<void> bddSetUp(WidgetTester tester, World world) async {
+      await theServerAlwaysReturnErrors(tester, world);
+    }
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      final World world = World.empty();
+      await bddSetUp(tester, world);
+      await theAppIsRunning(tester, world);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test/subdir/feature',
+      package: 'test',
+      input: featureFile,
+      generatorOptions: const GeneratorOptions(
+        addWorld: true,
+      ),
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
+}


### PR DESCRIPTION
This merge builds on from https://github.com/olexale/bdd_widget_test/pull/60 since it needed a few changes made there.

This PR adds/fixes the following;
- A addWorld flag to the generator options
- When this flag is true it adds a World object to the generated feature files, step files and hook files
- The World contains a parameters prop that is a key value map that can be edited by the developer.
- Since the hook file is now dynamic, changed it to use the constant declared method names
- Fixed an indent issue for if only hooks were enabled (without an after in the feature files)
- Fixed a formatting issue for the beforeEach hook