### PR TITLE
feat: add option to disable ensureInitialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.6.5] - Option to disable IntegrationTestBinding inclusion
+
+* Add includeIntegrationTestBinding option to disable/ enable IntegrationTestWidgetsFlutterBinding.ensureInitialized(); (by @eikebartels)
+
 ## [1.6.4] - Gherkin compliance
 
 * Add hooks (by @daniel-deboeverie-lemon)

--- a/lib/src/feature_file.dart
+++ b/lib/src/feature_file.dart
@@ -15,6 +15,7 @@ class FeatureFile {
     required this.package,
     required String input,
     this.isIntegrationTest = false,
+    this.includeIntegrationTestBinding = true,
     this.existingSteps = const <String, String>{},
     this.generatorOptions = const GeneratorOptions(),
   })  : _lines = _prepareLines(
@@ -65,19 +66,22 @@ class FeatureFile {
   final String featureDir;
   final String package;
   final bool isIntegrationTest;
+  /// Whether to include the integration test binding in the generated test for integration tests. Defaults to true.
+  final bool includeIntegrationTestBinding;
   final List<BddLine> _lines;
   final Map<String, String> existingSteps;
   final GeneratorOptions generatorOptions;
   final HookFile? hookFile;
 
   String get dartContent => generateFeatureDart(
-        _lines,
-        getStepFiles(),
-        generatorOptions.testMethodName,
-        _testerType,
-        _testerName,
-        isIntegrationTest,
-        hookFile,
+        lines: _lines,
+        steps: getStepFiles(),
+        testMethodName: generatorOptions.testMethodName,
+        testerType: _testerType,
+        testerName: _testerName,
+        isIntegrationTest: isIntegrationTest,
+        includeIntegrationTestBinding: includeIntegrationTestBinding,
+        hookFile: hookFile,
       );
 
   List<StepFile> getStepFiles() => _stepFiles;

--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -7,14 +7,29 @@ import 'package:bdd_widget_test/src/step_generator.dart';
 import 'package:bdd_widget_test/src/util/common.dart';
 import 'package:bdd_widget_test/src/util/constants.dart';
 
-String generateFeatureDart(
-  List<BddLine> lines,
-  List<StepFile> steps,
-  String testMethodName,
-  String testerType,
-  String testerName,
-  bool isIntegrationTest,
+
+/// Generates a Dart code for a feature based on the provided parameters.
+///
+/// The [lines] parameter is a list of [BddLine] objects representing the lines of the feature file.
+/// The [steps] parameter is a list of [StepFile] objects representing the step definitions.
+/// The [testMethodName] parameter is a string representing the name of the test method.
+/// The [testerType] parameter is a string representing the type of the tester.
+/// The [testerName] parameter is a string representing the name of the tester.
+/// The [isIntegrationTest] parameter is a boolean indicating whether the test is an integration test.
+/// The [includeIntegrationTestBinding] parameter is a boolean indicating whether to include the integration test binding.
+/// The [hookFile] parameter is an optional [HookFile] object representing the hook definitions.
+///
+/// Returns a string containing the generated Dart code for the feature.
+String generateFeatureDart({
+  required List<BddLine> lines,
+  required List<StepFile> steps,
+  required String testMethodName,
+  required String testerType,
+  required String testerName,
+  required bool isIntegrationTest,
+  required bool includeIntegrationTestBinding,
   HookFile? hookFile,
+  }
 ) {
   final sb = StringBuffer();
   sb.writeln('// GENERATED CODE - DO NOT MODIFY BY HAND');
@@ -70,7 +85,7 @@ String generateFeatureDart(
 
   sb.writeln();
   sb.writeln('void main() {');
-  if (isIntegrationTest) {
+  if (isIntegrationTest && includeIntegrationTestBinding) {
     sb.writeln('  IntegrationTestWidgetsFlutterBinding.ensureInitialized();');
     sb.writeln();
   }

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -34,4 +34,34 @@ void main() {
     );
     expect(feature.dartContent, expectedFeatureDart);
   });
+
+    test('integration-related lines are not added if includeIntegrationTestBinding is false', () {
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running.dart';
+
+void main() {
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      await theAppIsRunning(tester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: minimalFeatureFile,
+      isIntegrationTest: true,
+      includeIntegrationTestBinding: false,
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
 }


### PR DESCRIPTION
There are cases when you do not want the  'IntegrationTestWidgetsFlutterBinding.ensureInitialized();' to be include in the generated code. For example with the current patrol version. 

For this case, I have added the option `includeIntegrationTestBinding` with the default of `true`. If you set this option to `false` the line will not be written in the generated test file