### PR TITLE
feat: add option to disable ensureInitialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.6.5] - Option to disable IntegrationTestBinding inclusion
+
+* Add includeIntegrationTestBinding option to disable/ enable IntegrationTestWidgetsFlutterBinding.ensureInitialized(); (by @eikebartels)
+
 ## [1.6.4] - Gherkin compliance
 
 * Add hooks (by @daniel-deboeverie-lemon)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [1.6.5] - Option to disable IntegrationTestBinding inclusion
 
-* Add includeIntegrationTestBinding option to disable/ enable IntegrationTestWidgetsFlutterBinding.ensureInitialized(); (by @eikebartels)
+* Add includeIntegrationTestBinding option to control `IntegrationTestWidgetsFlutterBinding.ensureInitialized();` (by @eikebartels)
 
 ## [1.6.4] - Gherkin compliance
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,10 @@ targets:
           testMethodName: patrolTest
           testerName: $
           testerType: PatrolIntegrationTester
+          includeIntegrationTestBinding: false
 ```
+
+Since Patrol version 3.0.0, `IntegrationTestWidgetsFlutterBinding.ensureInitialized` must not be called. Set `includeIntegrationTestBinding` to `false`.
 
 ## Contributing
 

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -8,6 +8,7 @@ targets:
     builders:
       bdd_widget_test|featureBuilder:
         options:
+          includeIntegrationTestBinding: false # if false, integration test will not include binding; default is true
           stepFolderName: step # this trick is required to share steps between widget and integration tests
           # testMethodName: customTestMethodName
           include: package:bdd_widget_test/bdd_options.yaml # you may add defaul external steps with this line
@@ -33,3 +34,4 @@ targets:
         generate_for:
           - test/**
           - integration_test/**
+        

--- a/lib/bdd_widget_test.dart
+++ b/lib/bdd_widget_test.dart
@@ -31,6 +31,7 @@ class FeatureBuilder implements Builder {
       existingSteps: getExistingStepSubfolders(featureDir, options.stepFolder),
       input: contents,
       generatorOptions: options,
+      includeIntegrationTestBinding: generatorOptions.includeIntegrationTestBinding,
     );
 
     final featureDart = inputId.changeExtension('_test.dart');

--- a/lib/bdd_widget_test.dart
+++ b/lib/bdd_widget_test.dart
@@ -31,7 +31,8 @@ class FeatureBuilder implements Builder {
       existingSteps: getExistingStepSubfolders(featureDir, options.stepFolder),
       input: contents,
       generatorOptions: options,
-      includeIntegrationTestBinding: generatorOptions.includeIntegrationTestBinding,
+      includeIntegrationTestBinding:
+          generatorOptions.includeIntegrationTestBinding,
     );
 
     final featureDart = inputId.changeExtension('_test.dart');

--- a/lib/src/feature_file.dart
+++ b/lib/src/feature_file.dart
@@ -66,7 +66,7 @@ class FeatureFile {
   final String featureDir;
   final String package;
   final bool isIntegrationTest;
-  /// Whether to include the integration test binding in the generated test for integration tests. Defaults to true.
+
   final bool includeIntegrationTestBinding;
   final List<BddLine> _lines;
   final Map<String, String> existingSteps;
@@ -74,14 +74,14 @@ class FeatureFile {
   final HookFile? hookFile;
 
   String get dartContent => generateFeatureDart(
-        lines: _lines,
-        steps: getStepFiles(),
-        testMethodName: generatorOptions.testMethodName,
-        testerType: _testerType,
-        testerName: _testerName,
-        isIntegrationTest: isIntegrationTest,
-        includeIntegrationTestBinding: includeIntegrationTestBinding,
-        hookFile: hookFile,
+        _lines,
+        getStepFiles(),
+        generatorOptions.testMethodName,
+        _testerType,
+        _testerName,
+        isIntegrationTest,
+        includeIntegrationTestBinding,
+        hookFile,
       );
 
   List<StepFile> getStepFiles() => _stepFiles;

--- a/lib/src/feature_file.dart
+++ b/lib/src/feature_file.dart
@@ -15,6 +15,7 @@ class FeatureFile {
     required this.package,
     required String input,
     this.isIntegrationTest = false,
+    this.includeIntegrationTestBinding = true,
     this.existingSteps = const <String, String>{},
     this.generatorOptions = const GeneratorOptions(),
   })  : _lines = _prepareLines(
@@ -65,19 +66,22 @@ class FeatureFile {
   final String featureDir;
   final String package;
   final bool isIntegrationTest;
+  /// Whether to include the integration test binding in the generated test for integration tests. Defaults to true.
+  final bool includeIntegrationTestBinding;
   final List<BddLine> _lines;
   final Map<String, String> existingSteps;
   final GeneratorOptions generatorOptions;
   final HookFile? hookFile;
 
   String get dartContent => generateFeatureDart(
-        _lines,
-        getStepFiles(),
-        generatorOptions.testMethodName,
-        _testerType,
-        _testerName,
-        isIntegrationTest,
-        hookFile,
+        lines: _lines,
+        steps: getStepFiles(),
+        testMethodName: generatorOptions.testMethodName,
+        testerType: _testerType,
+        testerName: _testerName,
+        isIntegrationTest: isIntegrationTest,
+        includeIntegrationTestBinding: includeIntegrationTestBinding,
+        hookFile: hookFile,
       );
 
   List<StepFile> getStepFiles() => _stepFiles;

--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -7,14 +7,29 @@ import 'package:bdd_widget_test/src/step_generator.dart';
 import 'package:bdd_widget_test/src/util/common.dart';
 import 'package:bdd_widget_test/src/util/constants.dart';
 
-String generateFeatureDart(
-  List<BddLine> lines,
-  List<StepFile> steps,
-  String testMethodName,
-  String testerType,
-  String testerName,
-  bool isIntegrationTest,
+
+/// Generates a Dart code for a feature based on the provided parameters.
+///
+/// The [lines] parameter is a list of [BddLine] objects representing the lines of the feature file.
+/// The [steps] parameter is a list of [StepFile] objects representing the step definitions.
+/// The [testMethodName] parameter is a string representing the name of the test method.
+/// The [testerType] parameter is a string representing the type of the tester.
+/// The [testerName] parameter is a string representing the name of the tester.
+/// The [isIntegrationTest] parameter is a boolean indicating whether the test is an integration test.
+/// The [includeIntegrationTestBinding] parameter is a boolean indicating whether to include the integration test binding.
+/// The [hookFile] parameter is an optional [HookFile] object representing the hook definitions.
+///
+/// Returns a string containing the generated Dart code for the feature.
+String generateFeatureDart({
+  required List<BddLine> lines,
+  required List<StepFile> steps,
+  required String testMethodName,
+  required String testerType,
+  required String testerName,
+  required bool isIntegrationTest,
+  required bool includeIntegrationTestBinding,
   HookFile? hookFile,
+  }
 ) {
   final sb = StringBuffer();
   sb.writeln('// GENERATED CODE - DO NOT MODIFY BY HAND');
@@ -70,7 +85,7 @@ String generateFeatureDart(
 
   sb.writeln();
   sb.writeln('void main() {');
-  if (isIntegrationTest) {
+  if (isIntegrationTest && includeIntegrationTestBinding) {
     sb.writeln('  IntegrationTestWidgetsFlutterBinding.ensureInitialized();');
     sb.writeln();
   }

--- a/lib/src/feature_generator.dart
+++ b/lib/src/feature_generator.dart
@@ -7,29 +7,15 @@ import 'package:bdd_widget_test/src/step_generator.dart';
 import 'package:bdd_widget_test/src/util/common.dart';
 import 'package:bdd_widget_test/src/util/constants.dart';
 
-
-/// Generates a Dart code for a feature based on the provided parameters.
-///
-/// The [lines] parameter is a list of [BddLine] objects representing the lines of the feature file.
-/// The [steps] parameter is a list of [StepFile] objects representing the step definitions.
-/// The [testMethodName] parameter is a string representing the name of the test method.
-/// The [testerType] parameter is a string representing the type of the tester.
-/// The [testerName] parameter is a string representing the name of the tester.
-/// The [isIntegrationTest] parameter is a boolean indicating whether the test is an integration test.
-/// The [includeIntegrationTestBinding] parameter is a boolean indicating whether to include the integration test binding.
-/// The [hookFile] parameter is an optional [HookFile] object representing the hook definitions.
-///
-/// Returns a string containing the generated Dart code for the feature.
-String generateFeatureDart({
-  required List<BddLine> lines,
-  required List<StepFile> steps,
-  required String testMethodName,
-  required String testerType,
-  required String testerName,
-  required bool isIntegrationTest,
-  required bool includeIntegrationTestBinding,
+String generateFeatureDart(
+  List<BddLine> lines,
+  List<StepFile> steps,
+  String testMethodName,
+  String testerType,
+  String testerName,
+  bool isIntegrationTest,
+  bool includeIntegrationTestBinding,
   HookFile? hookFile,
-  }
 ) {
   final sb = StringBuffer();
   sb.writeln('// GENERATED CODE - DO NOT MODIFY BY HAND');

--- a/lib/src/generator_options.dart
+++ b/lib/src/generator_options.dart
@@ -82,20 +82,7 @@ Future<GeneratorOptions> _readFromPackage(String packageUri) async {
 GeneratorOptions readFromUri(Uri uri) {
   final rawYaml = fs.file(uri).readAsStringSync();
   final doc = loadYamlNode(rawYaml) as YamlMap;
-  return GeneratorOptions(
-    testMethodName: doc['testMethodName'] as String?,
-    testerType: doc['testerType'] as String?,
-    testerName: doc['testerName'] as String?,
-    externalSteps: (doc['externalSteps'] as List?)?.cast<String>(),
-    stepFolderName: doc['stepFolderName'] as String?,
-    addHooks: doc['addHooks'] as bool?,
-    hookFolderName: doc['hookFolderName'] as String?,
-    include: doc['include'] is String
-        ? [(doc['include'] as String)]
-        : (doc['include'] as YamlList?)?.value.cast<String>(),
-    includeIntegrationTestBinding:
-        doc['includeIntegrationTestBinding'] as bool?,
-  );
+  return GeneratorOptions.fromMap(doc.value.cast());
 }
 
 GeneratorOptions merge(GeneratorOptions a, GeneratorOptions b) =>

--- a/lib/src/generator_options.dart
+++ b/lib/src/generator_options.dart
@@ -18,13 +18,15 @@ class GeneratorOptions {
     bool? addHooks,
     String? hookFolderName,
     this.include,
+    bool? includeIntegrationTestBinding,
   })  : stepFolder = stepFolderName ?? _stepFolderName,
         testMethodName = testMethodName ?? _defaultTestMethodName,
         testerType = testerType ?? _defaultTesterType,
         testerName = testerName ?? _defaultTesterName,
         addHooks = addHooks ?? false,
         hookFolderName = hookFolderName ?? _hookFolderName,
-        externalSteps = externalSteps ?? const [];
+        externalSteps = externalSteps ?? const [], 
+        includeIntegrationTestBinding = includeIntegrationTestBinding ?? true;
 
   factory GeneratorOptions.fromMap(Map<String, dynamic> json) =>
       GeneratorOptions(
@@ -38,6 +40,7 @@ class GeneratorOptions {
         include: json['include'] is String
             ? [(json['include'] as String)]
             : (json['include'] as List?)?.cast<String>(),
+        includeIntegrationTestBinding: json['includeIntegrationTestBinding'] as bool?,
       );
 
   final String stepFolder;
@@ -48,6 +51,7 @@ class GeneratorOptions {
   final String hookFolderName;
   final List<String>? include;
   final List<String> externalSteps;
+  final bool includeIntegrationTestBinding;
 }
 
 Future<GeneratorOptions> flattenOptions(GeneratorOptions options) async {
@@ -88,6 +92,7 @@ GeneratorOptions readFromUri(Uri uri) {
     include: doc['include'] is String
         ? [(doc['include'] as String)]
         : (doc['include'] as YamlList?)?.value.cast<String>(),
+    includeIntegrationTestBinding: doc['includeIntegrationTestBinding'] as bool?,
   );
 }
 
@@ -108,4 +113,5 @@ GeneratorOptions merge(GeneratorOptions a, GeneratorOptions b) =>
           ? a.hookFolderName
           : b.hookFolderName,
       include: b.include,
+      includeIntegrationTestBinding: a.includeIntegrationTestBinding,
     );

--- a/lib/src/generator_options.dart
+++ b/lib/src/generator_options.dart
@@ -25,7 +25,7 @@ class GeneratorOptions {
         testerName = testerName ?? _defaultTesterName,
         addHooks = addHooks ?? false,
         hookFolderName = hookFolderName ?? _hookFolderName,
-        externalSteps = externalSteps ?? const [], 
+        externalSteps = externalSteps ?? const [],
         includeIntegrationTestBinding = includeIntegrationTestBinding ?? true;
 
   factory GeneratorOptions.fromMap(Map<String, dynamic> json) =>
@@ -40,7 +40,8 @@ class GeneratorOptions {
         include: json['include'] is String
             ? [(json['include'] as String)]
             : (json['include'] as List?)?.cast<String>(),
-        includeIntegrationTestBinding: json['includeIntegrationTestBinding'] as bool?,
+        includeIntegrationTestBinding:
+            json['includeIntegrationTestBinding'] as bool?,
       );
 
   final String stepFolder;
@@ -92,7 +93,8 @@ GeneratorOptions readFromUri(Uri uri) {
     include: doc['include'] is String
         ? [(doc['include'] as String)]
         : (doc['include'] as YamlList?)?.value.cast<String>(),
-    includeIntegrationTestBinding: doc['includeIntegrationTestBinding'] as bool?,
+    includeIntegrationTestBinding:
+        doc['includeIntegrationTestBinding'] as bool?,
   );
 }
 
@@ -113,5 +115,6 @@ GeneratorOptions merge(GeneratorOptions a, GeneratorOptions b) =>
           ? a.hookFolderName
           : b.hookFolderName,
       include: b.include,
-      includeIntegrationTestBinding: a.includeIntegrationTestBinding,
+      includeIntegrationTestBinding:
+          a.includeIntegrationTestBinding || b.includeIntegrationTestBinding,
     );

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -35,7 +35,9 @@ void main() {
     expect(feature.dartContent, expectedFeatureDart);
   });
 
-    test('integration-related lines are not added if includeIntegrationTestBinding is false', () {
+  test(
+      'integration-related lines are not added if includeIntegrationTestBinding is false',
+      () {
     const expectedFeatureDart = '''
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: unused_import, directives_ordering

--- a/test/integration_test.dart
+++ b/test/integration_test.dart
@@ -34,4 +34,34 @@ void main() {
     );
     expect(feature.dartContent, expectedFeatureDart);
   });
+
+    test('integration-related lines are not added if includeIntegrationTestBinding is false', () {
+    const expectedFeatureDart = '''
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: unused_import, directives_ordering
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import './step/the_app_is_running.dart';
+
+void main() {
+  group(\'\'\'Testing feature\'\'\', () {
+    testWidgets(\'\'\'Testing scenario\'\'\', (tester) async {
+      await theAppIsRunning(tester);
+    });
+  });
+}
+''';
+
+    final feature = FeatureFile(
+      featureDir: 'test.feature',
+      package: 'test',
+      input: minimalFeatureFile,
+      isIntegrationTest: true,
+      includeIntegrationTestBinding: false,
+    );
+    expect(feature.dartContent, expectedFeatureDart);
+  });
 }


### PR DESCRIPTION
There are cases when you do not want the  'IntegrationTestWidgetsFlutterBinding.ensureInitialized();' to be include in the generated code. For example with the current patrol version. 

For this case, I have added the option `includeIntegrationTestBinding` with the default of `true`. If you set this option to `false` the line will not be written in the generated test file