### PR TITLE
chore(deps): Upgrade file to 7.0.0

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 🐦 Setup Flutter SDK
         uses: flutter-actions/setup-flutter@v1
         with:
-          version: '3.16.8'
+          version: '3.19.0'
 
       - name: 🛠 Install dependencies
         run: flutter pub get

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   characters: ^1.2.0
   collection: ^1.15.0
   diacritic: ^0.1.3
-  file: ^6.1.4
+  file: ^7.0.0
   flutter:
     sdk: flutter
   flutter_test:


### PR DESCRIPTION
In flutter 3.19.0, `integration_test` use `file` 7.0.0.
I don't know if you want to put a more open constraint like file: “>=6.1.4 <8.0.0".